### PR TITLE
ADBDEV-1185 1.6.0  sync

### DIFF
--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -28,6 +28,7 @@ const apiVersion = "0.4.0"
 const Mebibyte = 1024 * 1024
 const Concurrency = 6
 const UploadChunkSize = int64(Mebibyte) * 10 // default 10MB
+const DownloadChunkSize = int64(Mebibyte) * 10 // default 10MB
 
 type Scope string
 

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -30,6 +30,8 @@ var _ = Describe("s3_plugin tests", func() {
 				"endpoint":                       "endpoint_name",
 				"backup_max_concurrent_requests": "5",
 				"backup_multipart_chunksize":     "7MB",
+				"restore_max_concurrent_requests": "5",
+				"restore_multipart_chunksize":     "7MB",
 			},
 		}
 	})
@@ -137,6 +139,27 @@ var _ = Describe("s3_plugin tests", func() {
 			Expect(chunkSize).To(Equal(int64(10 * 1024 * 1024)))
 
 			concurrency, err := s3plugin.GetUploadConcurrency(pluginConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(concurrency).To(Equal(6))
+		})
+		It("correctly parses download params from config", func() {
+			chunkSize, err := s3plugin.GetDownloadChunkSize(pluginConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chunkSize).To(Equal(int64(7 * 1024 * 1024)))
+
+			concurrency, err := s3plugin.GetDownloadConcurrency(pluginConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(concurrency).To(Equal(5))
+		})
+		It("uses default values if download params are not specified", func() {
+			delete(pluginConfig.Options, "restore_multipart_chunksize")
+			delete(pluginConfig.Options, "restore_max_concurrent_requests")
+
+			chunkSize, err := s3plugin.GetDownloadChunkSize(pluginConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chunkSize).To(Equal(int64(10 * 1024 * 1024)))
+
+			concurrency, err := s3plugin.GetDownloadConcurrency(pluginConfig)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(concurrency).To(Equal(6))
 		})


### PR DESCRIPTION
Previous download implementation (with the growing size of download
chunk and download buffers the size of the number of chunks) used to
cause unbounded growth of memory usage and, therefore, restore process
failure.
New logic implies fixed chunk size and usage of memory pool the size
of the number of workers as download buffers. Chunk size and the number
of workers can be adjusted in config file.

- restore_max_concurrent_requests - int value to configure
  download concurrency (number of workers). Default: 6.
- restore_multipart_chunksize - bytesize format ("5B", "10KB", "1MB"
  etc)
  to specify download chunk size. Default: 10MB.

## Here are some reminders before you submit the pull request, please:
- [] Run the unit tests with `make test`
- [] Run the plugin test bench as described [here](https://github.com/greenplum-db/gpbackup/tree/master/plugins)
- [] Describe in the PR if any [documentation](https://gpdb.docs.pivotal.io/latest/admin_guide/managing/backup-s3-plugin.html) changes are needed.
