### PR TITLE
ADBDEV-6248: Add new option to set logging level

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ options:
   bucket: <s3-bucket>
   folder: <s3-location>
   encryption: [on|off]
+  logger_verbosity: [error|info|verbose|debug]
   http_proxy: <http-proxy>
  ```
 
@@ -69,6 +70,7 @@ Below are the s3 plugin options
 | `bucket` | name of the S3 bucket. The bucket must exist with the necessary permissions |
 | `folder` | S3 location for backups. During a backup operation, the plugin creates the S3 location if it does not exist in the S3 bucket. |
 | `encryption` | Enable or disable SSL encryption to connect to S3. Valid values are on and off. On by default |
+| `logger_verbosity` | logger verbosity level. Valid values are error, info, verbose and debug. info by default |
 | `http_proxy` | your http proxy url |
 | `backup_max_concurrent_requests` | concurrency level for any file's backup request |
 | `backup_multipart_chunksize` | maximum buffer/chunk size for multipart transfers during backup |

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -73,6 +73,13 @@ type PluginOptions struct {
 	DownloadConcurrency int
 }
 
+var loggerVerbosityLut = map[string]int{
+	"error":   gplog.LOGERROR,
+	"info":    gplog.LOGINFO,
+	"verbose": gplog.LOGVERBOSE,
+	"debug":   gplog.LOGDEBUG,
+}
+
 func CleanupPlugin(c *cli.Context) error {
 	return nil
 }
@@ -100,18 +107,9 @@ func readAndValidatePluginConfig(configFile string) (*PluginConfig, error) {
 	return config, nil
 }
 
-func SetLoggerVerbosity(loggerVerbosity string) {
-	gplog.SetLogFileVerbosity(gplog.LOGINFO)
-	if loggerVerbosity == "error" {
-		gplog.SetVerbosity(gplog.LOGERROR)
-		gplog.SetLogFileVerbosity(gplog.LOGERROR)
-	} else if loggerVerbosity == "debug" {
-		gplog.SetVerbosity(gplog.LOGDEBUG)
-		gplog.SetLogFileVerbosity(gplog.LOGDEBUG)
-	} else if loggerVerbosity == "verbose" {
-		gplog.SetVerbosity(gplog.LOGVERBOSE)
-		gplog.SetLogFileVerbosity(gplog.LOGVERBOSE)
-	}
+func SetLoggerVerbosity(verbosity int) {
+	gplog.SetVerbosity(verbosity)
+	gplog.SetLogFileVerbosity(verbosity)
 }
 
 func InitializeAndValidateConfig(config *PluginConfig) error {
@@ -157,10 +155,11 @@ func InitializeAndValidateConfig(config *PluginConfig) error {
 	if opt.Encryption != "on" && opt.Encryption != "off" {
 		errTxt += fmt.Sprintf("Invalid encryption configuration. Valid choices are on or off.\n")
 	}
-	if opt.LoggerVerbosity != "error" && opt.LoggerVerbosity != "info" && opt.LoggerVerbosity != "verbose" && opt.LoggerVerbosity != "debug" {
+	loggerVerbosity, ok := loggerVerbosityLut[opt.LoggerVerbosity]
+	if !ok {
 		errTxt += fmt.Sprintf("Invalid logger_verbosity configuration. Valid choices are error, info, verbose or debug.\n")
 	}
-	SetLoggerVerbosity(opt.LoggerVerbosity)
+	SetLoggerVerbosity(loggerVerbosity)
 	if opt.BackupMultipartChunksize != "" {
 		chunkSize, err := bytesize.Parse(opt.BackupMultipartChunksize)
 		if err != nil {

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -57,6 +57,7 @@ type PluginOptions struct {
 	BackupMultipartChunksize     string `yaml:"backup_multipart_chunksize"`
 	Bucket                       string `yaml:"bucket"`
 	Encryption                   string `yaml:"encryption"`
+	LoggerVerbosity              string `yaml:"logger_verbosity"`
 	Endpoint                     string `yaml:"endpoint"`
 	Folder                       string `yaml:"folder"`
 	HttpProxy                    string `yaml:"http_proxy"`
@@ -99,6 +100,20 @@ func readAndValidatePluginConfig(configFile string) (*PluginConfig, error) {
 	return config, nil
 }
 
+func SetLoggerVerbosity(loggerVerbosity string) {
+	gplog.SetLogFileVerbosity(gplog.LOGINFO)
+	if loggerVerbosity == "error" {
+		gplog.SetVerbosity(gplog.LOGERROR)
+		gplog.SetLogFileVerbosity(gplog.LOGERROR)
+	} else if loggerVerbosity == "debug" {
+		gplog.SetVerbosity(gplog.LOGDEBUG)
+		gplog.SetLogFileVerbosity(gplog.LOGDEBUG)
+	} else if loggerVerbosity == "verbose" {
+		gplog.SetVerbosity(gplog.LOGVERBOSE)
+		gplog.SetLogFileVerbosity(gplog.LOGVERBOSE)
+	}
+}
+
 func InitializeAndValidateConfig(config *PluginConfig) error {
 	var err error
 	var errTxt string
@@ -110,6 +125,9 @@ func InitializeAndValidateConfig(config *PluginConfig) error {
 	}
 	if opt.Encryption == "" {
 		opt.Encryption = "on"
+	}
+	if opt.LoggerVerbosity == "" {
+		opt.LoggerVerbosity = "info"
 	}
 	opt.UploadChunkSize = DefaultUploadChunkSize
 	opt.UploadConcurrency = DefaultConcurrency
@@ -139,6 +157,10 @@ func InitializeAndValidateConfig(config *PluginConfig) error {
 	if opt.Encryption != "on" && opt.Encryption != "off" {
 		errTxt += fmt.Sprintf("Invalid encryption configuration. Valid choices are on or off.\n")
 	}
+	if opt.LoggerVerbosity != "error" && opt.LoggerVerbosity != "info" && opt.LoggerVerbosity != "verbose" && opt.LoggerVerbosity != "debug" {
+		errTxt += fmt.Sprintf("Invalid logger_verbosity configuration. Valid choices are error, info, verbose or debug.\n")
+	}
+	SetLoggerVerbosity(opt.LoggerVerbosity)
 	if opt.BackupMultipartChunksize != "" {
 		chunkSize, err := bytesize.Parse(opt.BackupMultipartChunksize)
 		if err != nil {

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -89,6 +89,37 @@ var _ = Describe("s3_plugin tests", func() {
 				err := s3plugin.InitializeAndValidateConfig(pluginConfig)
 				Expect(err).To(BeNil())
 				Expect(opts.LoggerVerbosity).To(Equal("info"))
+				Expect(gplog.GetVerbosity()).To(Equal(gplog.LOGINFO))
+				Expect(gplog.GetLogFileVerbosity()).To(Equal(gplog.LOGINFO))
+
+			})
+			It(`sets logger_verbosity to value "info"`, func() {
+				opts.LoggerVerbosity = "info"
+				err := s3plugin.InitializeAndValidateConfig(pluginConfig)
+				Expect(err).To(BeNil())
+				Expect(gplog.GetVerbosity()).To(Equal(gplog.LOGINFO))
+				Expect(gplog.GetLogFileVerbosity()).To(Equal(gplog.LOGINFO))
+			})
+			It(`sets logger_verbosity to value "error"`, func() {
+				opts.LoggerVerbosity = "error"
+				err := s3plugin.InitializeAndValidateConfig(pluginConfig)
+				Expect(err).To(BeNil())
+				Expect(gplog.GetVerbosity()).To(Equal(gplog.LOGERROR))
+				Expect(gplog.GetLogFileVerbosity()).To(Equal(gplog.LOGERROR))
+			})
+			It(`sets logger_verbosity to value "debug"`, func() {
+				opts.LoggerVerbosity = "debug"
+				err := s3plugin.InitializeAndValidateConfig(pluginConfig)
+				Expect(err).To(BeNil())
+				Expect(gplog.GetVerbosity()).To(Equal(gplog.LOGDEBUG))
+				Expect(gplog.GetLogFileVerbosity()).To(Equal(gplog.LOGDEBUG))
+			})
+			It(`sets logger_verbosity to value "verbose"`, func() {
+				opts.LoggerVerbosity = "verbose"
+				err := s3plugin.InitializeAndValidateConfig(pluginConfig)
+				Expect(err).To(BeNil())
+				Expect(gplog.GetVerbosity()).To(Equal(gplog.LOGVERBOSE))
+				Expect(gplog.GetLogFileVerbosity()).To(Equal(gplog.LOGVERBOSE))
 			})
 			It("sets backup upload chunk size to default if BackupMultipartChunkSize is not specified", func() {
 				opts.BackupMultipartChunksize = ""

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -166,16 +166,6 @@ var _ = Describe("s3_plugin tests", func() {
 			err := s3plugin.InitializeAndValidateConfig(pluginConfig)
 			Expect(err).To(HaveOccurred())
 		})
-		It("returns error when the encryption value is invalid", func() {
-			opts.Encryption = "invalid_value"
-			err := s3plugin.InitializeAndValidateConfig(pluginConfig)
-			Expect(err).To(HaveOccurred())
-		})
-		It("returns error when the logger_verbosity value is invalid", func() {
-			opts.LoggerVerbosity = "invalid_value"
-			err := s3plugin.InitializeAndValidateConfig(pluginConfig)
-			Expect(err).To(HaveOccurred())
-		})
 		It("returns error when the logger_verbosity value is invalid", func() {
 			opts.LoggerVerbosity = "invalid_value"
 			err := s3plugin.InitializeAndValidateConfig(pluginConfig)

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup-s3-plugin/s3plugin"
 	"github.com/urfave/cli"
@@ -23,6 +24,7 @@ func TestCluster(t *testing.T) {
 var _ = Describe("s3_plugin tests", func() {
 	var pluginConfig *s3plugin.PluginConfig
 	var opts *s3plugin.PluginOptions
+	gplog.InitializeLogging("gpbackup_s3_plugin_test", "")
 	BeforeEach(func() {
 		pluginConfig = &s3plugin.PluginConfig{
 			ExecutablePath: "/tmp/location",

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -82,6 +82,12 @@ var _ = Describe("s3_plugin tests", func() {
 				Expect(err).To(BeNil())
 				Expect(opts.Encryption).To(Equal("on"))
 			})
+			It(`sets logger_verbosity to default value "info" if none is specified`, func() {
+				opts.LoggerVerbosity = ""
+				err := s3plugin.InitializeAndValidateConfig(pluginConfig)
+				Expect(err).To(BeNil())
+				Expect(opts.LoggerVerbosity).To(Equal("info"))
+			})
 			It("sets backup upload chunk size to default if BackupMultipartChunkSize is not specified", func() {
 				opts.BackupMultipartChunksize = ""
 				err := s3plugin.InitializeAndValidateConfig(pluginConfig)
@@ -160,6 +166,16 @@ var _ = Describe("s3_plugin tests", func() {
 		})
 		It("returns error when the encryption value is invalid", func() {
 			opts.Encryption = "invalid_value"
+			err := s3plugin.InitializeAndValidateConfig(pluginConfig)
+			Expect(err).To(HaveOccurred())
+		})
+		It("returns error when the logger_verbosity value is invalid", func() {
+			opts.LoggerVerbosity = "invalid_value"
+			err := s3plugin.InitializeAndValidateConfig(pluginConfig)
+			Expect(err).To(HaveOccurred())
+		})
+		It("returns error when the logger_verbosity value is invalid", func() {
+			opts.LoggerVerbosity = "invalid_value"
 			err := s3plugin.InitializeAndValidateConfig(pluginConfig)
 			Expect(err).To(HaveOccurred())
 		})


### PR DESCRIPTION
Add new option to set logging level

The gpbackup_s3_plugin plugin does not set the logging level at all. This leads
to severe log pollution. Unfortunately, in order to pass the logging level with
which gpbackup was launched, we need to extend the plugin API. Therefore, this
patch simply adds a new option logger_verbosity to the plugin configuration
file, which allows us to set the desired logging level for the plugin.

The duplicate test for encryption has been replaced with a test for the new
option.